### PR TITLE
Expose logging config.

### DIFF
--- a/shakenfist_utilities/__init__.py
+++ b/shakenfist_utilities/__init__.py
@@ -1,0 +1,1 @@
+LOGGING_CONFIG = {}

--- a/shakenfist_utilities/api.py
+++ b/shakenfist_utilities/api.py
@@ -14,7 +14,10 @@ import sys
 import traceback
 
 
-LOG, _ = logs.setup(__name__)
+import shakenfist_utilities
+
+
+LOG, _ = logs.setup(__name__, **shakenfist_utilities.LOGGING_CONFIG)
 TESTING = False
 
 


### PR DESCRIPTION
I had an issue in Kerbside where it wasn't using the correct config for logging and the messages were therefore getting lost. This is a quick hack to correct that. I am unsure if there is a cleaner way to do this thing.