### PR TITLE
Add SHAKENFIST_LOG_TO_STDOUT environment variable.

### DIFF
--- a/shakenfist_utilities/logs.py
+++ b/shakenfist_utilities/logs.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import logging
+import sys
 import threading
 import importlib
 import os
@@ -175,7 +176,12 @@ class ConsoleLoggingHandler(logging.Handler):
 
 
 def setup(name, syslog=True, json=False, logpath=None):
-    """ Setup log formatter for a daemon. """
+    """Setup log formatter for a daemon.
+
+    If the environment variable SHAKENFIST_LOG_TO_STDOUT is set to '1', logging
+    will be redirected to stdout instead of syslog. This is useful for unit
+    tests where stestr captures stdout and only displays it for failing tests.
+    """
     logging.setLoggerClass(SyslogLogger)
 
     # Set root log level - higher handlers can set their own filter level
@@ -190,7 +196,12 @@ def setup(name, syslog=True, json=False, logpath=None):
               f'{str(log.handlers[0])}')
         log.removeHandler(log.handlers[0])
 
-    if syslog:
+    # Allow tests to redirect logging to stdout for capture by test runners
+    if os.environ.get('SHAKENFIST_LOG_TO_STDOUT') == '1':
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(
+            '%(levelname)s %(name)s: %(message)s'))
+    elif syslog:
         handler = logging_handlers.SysLogHandler(address='/dev/log')
         print(f'PID {os.getpid()} using syslog handler')
     elif logpath == 'stdout':


### PR DESCRIPTION
When set to '1', logging output is redirected to stdout instead of syslog. This allows test runners like stestr to capture log output and only display it for failing tests, reducing noise in test output.

Prompt: Add an environment variable to suppress syslog logging in unit tests so that stestr can capture logs and only show them for failing tests.



🤖 Assisted-By: [Claude Code](https://claude.com/claude-code)