### PR TITLE
Fix setup() crashing when the root logger has a handler.

### DIFF
--- a/shakenfist_utilities/logs.py
+++ b/shakenfist_utilities/logs.py
@@ -205,8 +205,14 @@ def setup(name, syslog=True, json=False, logpath=None):
 
     handler = None
     # Ensure our requested configuration is the one we have by removing
-    # pre-existing loggers.
-    while log.hasHandlers():
+    # this logger's own pre-existing handlers. Note: check ``log.handlers``
+    # (this logger's own handlers) rather than ``log.hasHandlers()``, which
+    # returns True when any *ancestor* (e.g. the root logger) has a handler.
+    # If a root handler is installed before setup() runs for a child logger
+    # -- as happens once the Shaken Fist Loki shipper attaches its handler
+    # to the root logger -- ``hasHandlers()`` is True while ``log.handlers``
+    # is empty, so ``log.handlers[0]`` would raise IndexError.
+    while log.handlers:
         log.removeHandler(log.handlers[0])
 
     # Allow tests to redirect logging to stdout for capture by test runners

--- a/shakenfist_utilities/tests/test_logs.py
+++ b/shakenfist_utilities/tests/test_logs.py
@@ -99,6 +99,31 @@ class LogsTestCase(testtools.TestCase):
         obj = json.loads(buf.getvalue().strip())
         self.assertEqual('still json', obj['message'])
 
+    def test_setup_with_root_handler_present(self):
+        # Regression: when a handler is attached to the root logger before
+        # setup() runs for a child logger (as the Shaken Fist Loki shipper
+        # does), setup() must not raise. log.hasHandlers() is True via the
+        # root ancestor while the child logger's own handlers list is empty,
+        # so the old `while log.hasHandlers(): removeHandler(log.handlers[0])`
+        # raised IndexError.
+        root = logging.getLogger()
+        root_handler = logging.StreamHandler(io.StringIO())
+        root.addHandler(root_handler)
+        self.addCleanup(root.removeHandler, root_handler)
+
+        # Must not raise IndexError.
+        log, _ = logs.setup('test-root-handler-present')
+
+        # The root handler is left intact (setup only strips the child
+        # logger's own handlers).
+        self.assertIn(root_handler, root.handlers)
+
+        # And the logger still works.
+        buf = self._capture(log)
+        log.info('after root handler')
+        obj = json.loads(buf.getvalue().strip())
+        self.assertEqual('after root handler', obj['message'])
+
     def test_setup_console_is_not_json(self):
         log = logs.setup_console('test-console')
         buf = io.StringIO()


### PR DESCRIPTION
setup() stripped a logger's pre-existing handlers with

    while log.hasHandlers():
        log.removeHandler(log.handlers[0])

but hasHandlers() returns True when any *ancestor* (notably the root logger) has a handler, while log.handlers contains only the logger's own handlers. So once a handler is attached to the root logger and setup() is then called for a child logger whose own handler list is empty, log.handlers[0] raises IndexError.

This is exactly what the Shaken Fist Loki log shipper triggers: it attaches its handler to the root logger, after which the next logs.setup(__name__) for a child logger crashes the daemon (the sf-database daemon failed to start with IndexError in CI).

Check log.handlers (the logger's own handlers) instead. This preserves the intent -- strip this logger's own handlers before installing ours -- and leaves ancestor/root handlers untouched. Adds a regression test that installs a root handler before calling setup().


Assisted-By: Claude Opus 4.8 (1M context, medium effort) <noreply@anthropic.com>